### PR TITLE
fix: separate version argument from binary path in healthchecker test

### DIFF
--- a/Formula/docker-container-healthchecker.rb
+++ b/Formula/docker-container-healthchecker.rb
@@ -17,6 +17,6 @@ class DockerContainerHealthchecker < Formula
   end
 
   test do
-    system "#{bin}/docker-container-healthchecker" "version"
+    system "#{bin}/docker-container-healthchecker", "version"
   end
 end


### PR DESCRIPTION
## Summary

The `brew test` block for `docker-container-healthchecker` invokes a nonexistent binary ending in `healthcheckerversion` instead of running `docker-container-healthchecker version`. Ruby concatenates adjacent string literals at parse time, so `"#{bin}/docker-container-healthchecker" "version"` becomes a single string. Adding a comma separates the two into distinct argv entries so `version` is passed as an argument.

Observed in CI run https://github.com/dokku/homebrew-repo/actions/runs/24525123950/job/71693171772:

```
BuildError: Failed executing: /opt/homebrew/Cellar/docker-container-healthchecker/v0.11.3/bin/docker-container-healthcheckerversion
```