### PR TITLE
feat: add sha256 checksums for docker-container-healthchecker binaries

### DIFF
--- a/Formula/docker-container-healthchecker.rb
+++ b/Formula/docker-container-healthchecker.rb
@@ -4,9 +4,13 @@ class DockerContainerHealthchecker < Formula
 
   version "v0.11.3"
 
-  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
-
-  url "https://github.com/dokku/docker-container-healthchecker/releases/download/#{version}/docker-container-healthchecker-darwin-#{arch}"
+  if Hardware::CPU.intel?
+    url "https://github.com/dokku/docker-container-healthchecker/releases/download/#{version}/docker-container-healthchecker-darwin-amd64"
+    sha256 "583613f0ee58f9939c9171f6c0b2a2b17db4422742da97065dd4b184014043f7"
+  else
+    url "https://github.com/dokku/docker-container-healthchecker/releases/download/#{version}/docker-container-healthchecker-darwin-arm64"
+    sha256 "4a42748d719cdc2d09452c852998f9d9e24bc590c29609dd7df5c20c6d8acb49"
+  end
 
   license "BSD-3-Clause"
 


### PR DESCRIPTION
## Summary

Pairs each architecture-specific download URL in `Formula/docker-container-healthchecker.rb` with its `sha256`, so Homebrew verifies the integrity of the downloaded binaries. Checksums computed from the published v0.11.3 darwin release artifacts.