### PR TITLE
feat(docker-port-forward): add formula at 0.1.0

### DIFF
--- a/Formula/docker-port-forward.rb
+++ b/Formula/docker-port-forward.rb
@@ -1,0 +1,26 @@
+class DockerPortForward < Formula
+  desc "Forward local ports to running Docker containers or Compose services"
+  homepage "https://github.com/dokku/docker-port-forward"
+
+  version "0.1.0"
+
+  if Hardware::CPU.intel?
+    url "https://github.com/dokku/docker-port-forward/releases/download/#{version}/docker-port-forward-darwin-amd64"
+    sha256 "df714c9f36ed262b885586efc42987184fc757a947174108e95ce3799f7d91ed"
+  else
+    url "https://github.com/dokku/docker-port-forward/releases/download/#{version}/docker-port-forward-darwin-arm64"
+    sha256 "5b5c6666e1cf56340d77374ae10933d3ad49b318b30da8e1c72717d1409c383a"
+  end
+
+  license "MIT"
+
+  def install
+    arch = Hardware::CPU.intel? ? "amd64" : "arm64"
+
+    bin.install "docker-port-forward-darwin-#{arch}" => "docker-port-forward"
+  end
+
+  test do
+    system "#{bin}/docker-port-forward", "--help"
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Formula/docker-port-forward.rb` pinned at the current `0.1.0` release of `dokku/docker-port-forward`, modeled on the existing `docker-container-healthchecker.rb`.
- Covers `darwin-amd64` and `darwin-arm64` via the `Hardware::CPU.intel?` branch, matching the tap's existing convention.
- Paired with a forthcoming workflow change in `dokku/docker-port-forward` that will open bump PRs here on every tagged release.

SHA256s computed from the `0.1.0` release assets at https://github.com/dokku/docker-port-forward/releases/tag/0.1.0.