### PR TITLE
feat(docker-run-export): add formula at v0.4.0

### DIFF
--- a/Formula/docker-run-export.rb
+++ b/Formula/docker-run-export.rb
@@ -1,0 +1,27 @@
+class DockerRunExport < Formula
+  desc "Export docker run flags to various formats"
+  homepage "https://github.com/dokku/docker-run-export"
+  license "MIT"
+
+  version "v0.4.0"
+
+  on_arm do
+    url "https://github.com/dokku/docker-run-export/releases/download/#{version}/docker-run-export-darwin-arm64"
+    sha256 "e00cbfd8dddf4ce97bc517d2d1cc9d8153f037ca3f52b7345d83749b9b2828b9"
+  end
+
+  on_intel do
+    url "https://github.com/dokku/docker-run-export/releases/download/#{version}/docker-run-export-darwin-amd64"
+    sha256 "f518def66e95c96083c6121c1dd876c9c3899917fac718ea7104c03eeabb26ae"
+  end
+
+  def install
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+
+    bin.install "docker-run-export-darwin-#{arch}" => "docker-run-export"
+  end
+
+  test do
+    system "#{bin}/docker-run-export", "version"
+  end
+end


### PR DESCRIPTION
## Summary

Seeds the formula so dokku/docker-run-export's tagged-release workflow can bump it on each tag push, matching the pattern used by dokku and docker-container-healthchecker.

The SHA256 values were computed from the `docker-run-export-darwin-amd64` and `docker-run-export-darwin-arm64` assets on the v0.4.0 GitHub release. Uses `#{version}` URL interpolation so future bumps only need to rewrite `version` and both `sha256` lines.