### PR TITLE
feat(docker-container-healthchecker): register binary as Docker CLI plugin

### DIFF
--- a/Formula/docker-container-healthchecker.rb
+++ b/Formula/docker-container-healthchecker.rb
@@ -18,9 +18,11 @@ class DockerContainerHealthchecker < Formula
     arch = Hardware::CPU.intel? ? "amd64" : "arm64"
 
     bin.install "docker-container-healthchecker-darwin-#{arch}" => "docker-container-healthchecker"
+    (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-container-healthchecker"
   end
 
   test do
     system "#{bin}/docker-container-healthchecker", "version"
+    assert_predicate prefix/"lib/docker/cli-plugins/docker-container-healthchecker", :exist?
   end
 end


### PR DESCRIPTION
## Summary

- Symlinks the installed `docker-container-healthchecker` binary into `#{prefix}/lib/docker/cli-plugins` so it is picked up by Docker's CLI plugin lookup path on macOS.
- After `brew install docker-container-healthchecker`, `docker container-healthchecker [subcommand]` works identically to the bare binary.
- Extends the formula's `test` block to assert the symlink is created.

Pairs with dokku/docker-container-healthchecker which adds the `docker-cli-plugin-metadata` subcommand, arg-strip logic gated on `DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND`, and Docker CLI plugin documentation.