### PR TITLE
fix(docker-container-healthchecker): use docker-healthcheck as plugin name

### DIFF
--- a/Formula/docker-container-healthchecker.rb
+++ b/Formula/docker-container-healthchecker.rb
@@ -18,11 +18,11 @@ class DockerContainerHealthchecker < Formula
     arch = Hardware::CPU.intel? ? "amd64" : "arm64"
 
     bin.install "docker-container-healthchecker-darwin-#{arch}" => "docker-container-healthchecker"
-    (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-container-healthchecker"
+    (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-container-healthchecker" => "docker-healthcheck"
   end
 
   test do
     system "#{bin}/docker-container-healthchecker", "version"
-    assert_predicate prefix/"lib/docker/cli-plugins/docker-container-healthchecker", :exist?
+    assert_predicate prefix/"lib/docker/cli-plugins/docker-healthcheck", :exist?
   end
 end


### PR DESCRIPTION
## Summary

- Docker CLI plugin names must match `^[a-z][a-z0-9]*$` (no hyphens). The previous symlink name `docker-container-healthchecker` was rejected by Docker.
- Renames the cli-plugins symlink to `docker-healthcheck`, making the plugin invocable as `docker healthcheck [subcommand]`.

Follow-up to dokku/homebrew-repo#115.