### PR TITLE
feat: add Docker CLI plugin symlink for docker-run-export

### DIFF
--- a/Formula/docker-run-export.rb
+++ b/Formula/docker-run-export.rb
@@ -19,9 +19,11 @@ class DockerRunExport < Formula
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
 
     bin.install "docker-run-export-darwin-#{arch}" => "docker-run-export"
+    (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-run-export" => "docker-dre"
   end
 
   test do
     system "#{bin}/docker-run-export", "version"
+    assert_predicate prefix/"lib/docker/cli-plugins/docker-dre", :exist?
   end
 end


### PR DESCRIPTION
## Summary

- Symlinks the `docker-run-export` binary into Homebrew's `lib/docker/cli-plugins/` as `docker-dre`.
- After `brew install docker-run-export`, users can invoke `docker dre run ...` as a Docker CLI plugin.

Paired with dokku/docker-run-export#262.