### PR TITLE
feat(docker-port-forward): install as Docker CLI plugin

### DIFF
--- a/Formula/docker-port-forward.rb
+++ b/Formula/docker-port-forward.rb
@@ -18,9 +18,11 @@ class DockerPortForward < Formula
     arch = Hardware::CPU.intel? ? "amd64" : "arm64"
 
     bin.install "docker-port-forward-darwin-#{arch}" => "docker-port-forward"
+    (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-port-forward" => "docker-pf"
   end
 
   test do
     system "#{bin}/docker-port-forward", "--help"
+    assert_predicate prefix/"lib/docker/cli-plugins/docker-pf", :exist?
   end
 end


### PR DESCRIPTION
## Summary

- Add `install_symlink` in the formula to create `lib/docker/cli-plugins/docker-pf` pointing to the installed binary
- Add test assertion that the plugin symlink exists

This enables Homebrew users to use `docker pf` as a Docker CLI plugin after installation.