### PR TITLE
feat(docker-orchestrate): install as Docker CLI plugin

### DIFF
--- a/Formula/docker-orchestrate.rb
+++ b/Formula/docker-orchestrate.rb
@@ -18,9 +18,11 @@ class DockerOrchestrate < Formula
     arch = Hardware::CPU.intel? ? "amd64" : "arm64"
 
     bin.install "docker-orchestrate-darwin-#{arch}" => "docker-orchestrate"
+    (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-orchestrate"
   end
 
   test do
     system "#{bin}/docker-orchestrate", "version"
+    assert_predicate prefix/"lib/docker/cli-plugins/docker-orchestrate", :exist?
   end
 end


### PR DESCRIPTION
## Summary

- Add symlink from `lib/docker/cli-plugins/docker-orchestrate` to the installed binary so Docker automatically discovers it as a CLI plugin
- Add test assertion that the plugin symlink exists
- Matches the pattern used by `docker-container-healthchecker`