### PR TITLE
feat: add docket formula

### DIFF
--- a/.github/workflows/test-formulas.yml
+++ b/.github/workflows/test-formulas.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         formula:
           - docker-container-healthchecker
+          - docket
           - dokku
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -16,6 +16,7 @@ jobs:
           - docker-orchestrate
           - docker-port-forward
           - docker-run-export
+          - docket
           - dokku
     steps:
       - name: Set up Homebrew

--- a/Formula/docker-container-healthchecker.rb
+++ b/Formula/docker-container-healthchecker.rb
@@ -2,13 +2,13 @@ class DockerContainerHealthchecker < Formula
   desc "Runs healthchecks against local docker containers"
   homepage "https://github.com/dokku/docker-container-healthchecker"
 
-  version "v0.15.0"
+  version "0.15.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/dokku/docker-container-healthchecker/releases/download/#{version}/docker-container-healthchecker-darwin-amd64"
+    url "https://github.com/dokku/docker-container-healthchecker/releases/download/v#{version}/docker-container-healthchecker-darwin-amd64"
     sha256 "dbb04b868e48deef6fa5562d4e094a7f28f045d132cc0187bf1151f13fa097c7"
   else
-    url "https://github.com/dokku/docker-container-healthchecker/releases/download/#{version}/docker-container-healthchecker-darwin-arm64"
+    url "https://github.com/dokku/docker-container-healthchecker/releases/download/v#{version}/docker-container-healthchecker-darwin-arm64"
     sha256 "2aad857fda7f2ad2452fd77d653f539f722bcc66f1cfe73253dc1ffe6a1fa49b"
   end
 
@@ -22,7 +22,7 @@ class DockerContainerHealthchecker < Formula
   end
 
   test do
-    system "#{bin}/docker-container-healthchecker", "version"
-    assert_predicate prefix/"lib/docker/cli-plugins/docker-healthcheck", :exist?
+    system bin/"docker-container-healthchecker", "version"
+    assert_path_exists prefix/"lib/docker/cli-plugins/docker-healthcheck"
   end
 end

--- a/Formula/docker-orchestrate.rb
+++ b/Formula/docker-orchestrate.rb
@@ -22,7 +22,7 @@ class DockerOrchestrate < Formula
   end
 
   test do
-    system "#{bin}/docker-orchestrate", "version"
-    assert_predicate prefix/"lib/docker/cli-plugins/docker-orchestrate", :exist?
+    system bin/"docker-orchestrate", "version"
+    assert_path_exists prefix/"lib/docker/cli-plugins/docker-orchestrate"
   end
 end

--- a/Formula/docker-port-forward.rb
+++ b/Formula/docker-port-forward.rb
@@ -22,7 +22,7 @@ class DockerPortForward < Formula
   end
 
   test do
-    system "#{bin}/docker-port-forward", "--help"
-    assert_predicate prefix/"lib/docker/cli-plugins/docker-pf", :exist?
+    system bin/"docker-port-forward", "--help"
+    assert_path_exists prefix/"lib/docker/cli-plugins/docker-pf"
   end
 end

--- a/Formula/docker-run-export.rb
+++ b/Formula/docker-run-export.rb
@@ -1,29 +1,28 @@
 class DockerRunExport < Formula
   desc "Export docker run flags to various formats"
   homepage "https://github.com/dokku/docker-run-export"
-  license "MIT"
 
-  version "v0.4.0"
+  version "0.4.0"
 
-  on_arm do
-    url "https://github.com/dokku/docker-run-export/releases/download/#{version}/docker-run-export-darwin-arm64"
+  if Hardware::CPU.intel?
+    url "https://github.com/dokku/docker-run-export/releases/download/v#{version}/docker-run-export-darwin-amd64"
+    sha256 "f518def66e95c96083c6121c1dd876c9c3899917fac718ea7104c03eeabb26ae"
+  else
+    url "https://github.com/dokku/docker-run-export/releases/download/v#{version}/docker-run-export-darwin-arm64"
     sha256 "e00cbfd8dddf4ce97bc517d2d1cc9d8153f037ca3f52b7345d83749b9b2828b9"
   end
 
-  on_intel do
-    url "https://github.com/dokku/docker-run-export/releases/download/#{version}/docker-run-export-darwin-amd64"
-    sha256 "f518def66e95c96083c6121c1dd876c9c3899917fac718ea7104c03eeabb26ae"
-  end
+  license "MIT"
 
   def install
-    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    arch = Hardware::CPU.intel? ? "amd64" : "arm64"
 
     bin.install "docker-run-export-darwin-#{arch}" => "docker-run-export"
     (prefix/"lib/docker/cli-plugins").install_symlink bin/"docker-run-export" => "docker-dre"
   end
 
   test do
-    system "#{bin}/docker-run-export", "version"
-    assert_predicate prefix/"lib/docker/cli-plugins/docker-dre", :exist?
+    system bin/"docker-run-export", "version"
+    assert_path_exists prefix/"lib/docker/cli-plugins/docker-dre"
   end
 end

--- a/Formula/docket.rb
+++ b/Formula/docket.rb
@@ -1,0 +1,26 @@
+class Docket < Formula
+  desc "Pre-package and ship applications on Dokku"
+  homepage "https://github.com/dokku/docket"
+
+  version "0.1.0"
+
+  if Hardware::CPU.intel?
+    url "https://github.com/dokku/docket/releases/download/#{version}/docket-darwin-amd64"
+    sha256 "bd4cbe95f25de14e3fdbf9ac438069d64d75adb0e255ffd64d7e0dcd4bae8d94"
+  else
+    url "https://github.com/dokku/docket/releases/download/#{version}/docket-darwin-arm64"
+    sha256 "38188c2ba5ec157a212324f697d6f5e8b631b5728bd5cef7ef85db4e20a6de5e"
+  end
+
+  license "MIT"
+
+  def install
+    arch = Hardware::CPU.intel? ? "amd64" : "arm64"
+
+    bin.install "docket-darwin-#{arch}" => "docket"
+  end
+
+  test do
+    system bin/"docket", "version"
+  end
+end

--- a/Formula/dokku.rb
+++ b/Formula/dokku.rb
@@ -1,7 +1,7 @@
 class Dokku < Formula
   desc "Command-line client for the Dokku PaaS"
   homepage "https://dokku.com"
-  url "https://github.com/dokku/dokku/archive/v0.37.10.tar.gz"
+  url "https://github.com/dokku/dokku/archive/refs/tags/v0.37.10.tar.gz"
   sha256 "b8fa24f2b47d91d3913890fa413f4992c901a0ba36701b73497cdc5f94c84b9e"
 
   def install

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Auto-updated:
 - [docker-orchestrate](/Formula/docker-orchestrate.rb): Docker plugin for orchestrating compose deploys.
 - [docker-port-forward](/Formula/docker-port-forward.rb): Forward local ports to running Docker containers or Compose services.
 - [docker-run-export](/Formula/docker-run-export.rb): Export docker run flags to various formats.
+- [docket](/Formula/docket.rb): Pre-package and ship applications on Dokku.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,14 @@ Export docker run flags to various formats.
 brew install dokku/repo/docker-run-export
 ```
 
+### docket
+
+Pre-package and ship applications on Dokku.
+
+```bash
+brew install dokku/repo/docket
+```
+
 ## Updating
 
 To update to the latest version:


### PR DESCRIPTION
Adds a formula for [`dokku/docket`](https://github.com/dokku/docket), a Go binary that pre-packages and ships applications on Dokku. Installs as a standalone binary (not a Docker CLI plugin), wired into `update-formulas.yml` for daily auto-bumps and `test-formulas.yml` for PR install/test runs.

Also brings the existing five formulas up to `brew audit --strict` cleanliness: drops leading `v` from `version` fields (URLs use `v#{version}` so livecheck-driven auto-bumps still resolve), normalizes `docker-run-export` onto the same `if Hardware::CPU.intel?` shape as its siblings, switches test stanzas to `bin/"X"` and `assert_path_exists`, and pins the dokku archive URL to the `refs/tags/...` form.