### PR TITLE
fix: drop stray v prefix from docker-run-export version

### DIFF
--- a/Formula/docker-run-export.rb
+++ b/Formula/docker-run-export.rb
@@ -2,7 +2,7 @@ class DockerRunExport < Formula
   desc "Export docker run flags to various formats"
   homepage "https://github.com/dokku/docker-run-export"
 
-  version "v0.5.0"
+  version "0.5.0"
 
   if Hardware::CPU.intel?
     url "https://github.com/dokku/docker-run-export/releases/download/v#{version}/docker-run-export-darwin-amd64"


### PR DESCRIPTION
The merged auto-bump for docker-run-export landed before commit 88eff87 with `version "v0.5.0"`. The URL line interpolates `v#{version}` and produces a `vv0.5.0` download path that 404s, so installing or testing the formula on master fails today. Strip the leading `v` so the URL resolves to `releases/download/v0.5.0/...`.