### PR TITLE
ci: strip stray v prefix from bumped formula version stanza

### DIFF
--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -42,3 +42,23 @@ jobs:
           brew bump-formula-pr dokku/repo/${{ matrix.formula }} --no-browse --no-fork --version=$VERSION --base master
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sanitize version stanza on bot branch
+        if: success()
+        run: |
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          if [ "$BRANCH" = "master" ] || [ "$BRANCH" = "HEAD" ]; then
+            echo "Not on a bot branch (current: $BRANCH); nothing to sanitize."
+            exit 0
+          fi
+
+          FILE="Formula/${{ matrix.formula }}.rb"
+          if ! grep -qE '^  version "v' "$FILE"; then
+            echo "No stray v prefix in $FILE; nothing to sanitize."
+            exit 0
+          fi
+
+          sed -i '' -E 's/^(  version ")v/\1/' "$FILE"
+          git add "$FILE"
+          git commit --amend --no-edit
+          git push --force-with-lease origin "$BRANCH"


### PR DESCRIPTION
The workflow already strips a leading `v` from the livecheck output, but `brew bump-formula-pr` reintroduces the prefix in the formula's `version` stanza when the upstream tag carries one (the upstream tag drives the new value, not `--version`). The result is `version "vX.Y.Z"` paired with a URL line that interpolates `v#{version}`, producing `vvX.Y.Z` paths that 404 (see PR #132 for docker-container-healthchecker v0.15.2). Add a post-bump step that, when on the bot's branch, rewrites a stray `v` prefix in the version stanza, amends the bot commit, and force-pushes the bot branch so the resulting PR builds against the real release URL.